### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/CyberNilsen/CyberVault/security/code-scanning/1](https://github.com/CyberNilsen/CyberVault/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- `contents: read` is sufficient for accessing repository contents during the `actions/checkout` step.
- No other permissions appear to be required for the current workflow.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, as there is only one job (`build`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
